### PR TITLE
Removed install command in favor of upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Kap-Helm
 This action creates a docker container with AWS CLI and Helm v3 available for AWS EKS deployments. The entrypoint.sh script assumes that the action is used in a repo where the helm chart structure is located in an `apps/<application>/` directory structure and that values files are named with an environment leading the `-values.yaml`. A value in the `<env>-values.yaml` file will need to use a placeholder for the deployment image with a value of `RELEASE_IMAGE`
 
+NOTE: The entrypoint.sh script assumes the initial deployment has already occurred as it uses the `upgrade` command and not an `install` command.
+
 For example
 ```bash
 repo

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,4 @@ echo "$KUBE_CONFIG" | base64 -d > /tmp/kube_config
 export KUBECONFIG=/tmp/kube_config
 
 sed -i "s/RELEASE_IMAGE/$RELEASE_IMAGE/g" apps/$APPLICATION/$ENVIRONMENT-values.yaml
-helm install $APPLICATION apps/$APPLICATION/ --namespace $KUBE_NAMESPACE -f apps/$APPLICATION/$ENVIRONMENT-values.yaml
+helm upgrade $APPLICATION apps/$APPLICATION/ --namespace $KUBE_NAMESPACE -f apps/$APPLICATION/$ENVIRONMENT-values.yaml


### PR DESCRIPTION
The `install` command doesn't allow for updated images. Changing the command in favor of `upgrade` to accommodate most common use case. Will add a "feature" later to allow for installs as well for new deployments.