### PR TITLE
Removed unnecessary yum update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM amazon/aws-cli:latest
 ENV VERIFY_CHECKSUM=false
 
 # Install dependencies
-RUN yum update && yum install -y \
+RUN yum install -y \
     git \
     tar
 


### PR DESCRIPTION
Yum update command was causing failures due to missing user input. The update is unnecessary at the moment, so removing it.